### PR TITLE
Add Aliases to folders

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,16 @@
+{
+  "plugins": [
+    [ 'module-resolver',
+      {
+        root: ['./src'],
+        alias: {
+          Components: './src/components',
+          Constants: './src/constants',
+          Redux: './src/redux',
+          Screens: './src/screens',
+          Services: './src/services',
+        },
+      },
+    ]
+  ]
+}

--- a/App.js
+++ b/App.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { PersistGate } from 'redux-persist/integration/react';
 
-import { store, persistor } from './src/redux';
+import { store, persistor } from 'Redux';
 
 import MainStackNavigator from './src/navigation/MainStackNavigator';
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@react-native-community/eslint-config": "^0.0.7",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^25.1.0",
+    "babel-plugin-module-resolver": "^4.0.0",
     "eslint": "^6.8.0",
     "eslint-plugin-react": "^7.19.0",
     "eslint-plugin-react-native": "^3.8.1",

--- a/src/components/Button/styles.js
+++ b/src/components/Button/styles.js
@@ -1,6 +1,6 @@
 import { StyleSheet } from 'react-native';
 
-import { BUTTON_BACKGROUND, WHITE } from '../../constants/colors';
+import { BUTTON_BACKGROUND, WHITE } from 'Constants/colors';
 
 export default StyleSheet.create({
   buttonContainer: {

--- a/src/navigation/MainStackNavigator.js
+++ b/src/navigation/MainStackNavigator.js
@@ -2,11 +2,11 @@ import * as React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 
-import Welcome from '../screens/Welcome';
-import ScreenTwo from '../screens/ScreenTwo';
-import ScreenThree from '../screens/ScreenThree';
+import Welcome from 'Screens/Welcome';
+import ScreenTwo from 'Screens/ScreenTwo';
+import ScreenThree from 'Screens/ScreenThree';
 
-import { HEADER_BACKGROUND, WHITE } from '../constants/colors';
+import { HEADER_BACKGROUND, WHITE } from 'Constants/colors';
 
 const Stack = createStackNavigator();
 

--- a/src/redux/appReducer/sagas.js
+++ b/src/redux/appReducer/sagas.js
@@ -7,7 +7,7 @@ import { Alert } from 'react-native';
 import * as constants from './constants';
 import * as actions from './actions';
 
-import exampleServices from '../../services/exampleServices';
+import exampleServices from 'Services/exampleServices';
 
 function* fetchData() {
   while (true) {

--- a/src/screens/ScreenThree/index.js
+++ b/src/screens/ScreenThree/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { View, Text } from 'react-native';
 import PropTypes from 'prop-types';
 
-import Button from '../../components/Button';
+import Button from 'Components/Button';
 
 import styles from './styles';
 

--- a/src/screens/ScreenThree/styles.js
+++ b/src/screens/ScreenThree/styles.js
@@ -1,6 +1,6 @@
 import { StyleSheet } from 'react-native';
 
-import { BLACK, WHITE } from '../../constants/colors';
+import { BLACK, WHITE } from 'Constants/colors';
 
 export default StyleSheet.create({
   container: {

--- a/src/screens/ScreenTwo/index.js
+++ b/src/screens/ScreenTwo/index.js
@@ -5,7 +5,7 @@ import {
 } from 'react-native';
 import PropTypes from 'prop-types';
 
-import Button from '../../components/Button';
+import Button from 'Components/Button';
 
 import styles from './styles';
 

--- a/src/screens/ScreenTwo/styles.js
+++ b/src/screens/ScreenTwo/styles.js
@@ -1,6 +1,6 @@
 import { StyleSheet } from 'react-native';
 
-import { BLACK, WHITE } from '../../constants/colors';
+import { BLACK, WHITE } from 'Constants/colors';
 
 export default StyleSheet.create({
   container: {

--- a/src/screens/Welcome/index.js
+++ b/src/screens/Welcome/index.js
@@ -7,9 +7,9 @@ import {
 } from 'react-native';
 import PropTypes from 'prop-types';
 
-import Button from '../../components/Button';
+import Button from 'Components/Button';
 
-import { fetchData } from '../../redux/appReducer/actions';
+import { fetchData } from 'Redux/appReducer/actions';
 
 import styles from './styles';
 

--- a/src/screens/Welcome/styles.js
+++ b/src/screens/Welcome/styles.js
@@ -1,6 +1,6 @@
 import { StyleSheet } from 'react-native';
 
-import { BLACK } from '../../constants/colors';
+import { BLACK } from 'Constants/colors';
 
 export default StyleSheet.create({
   container: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1684,6 +1684,17 @@ babel-plugin-jest-hoist@^25.1.0:
   dependencies:
     "@types/babel__traverse" "^7.0.6"
 
+babel-plugin-module-resolver@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-module-resolver/-/babel-plugin-module-resolver-4.0.0.tgz#8f3a3d9d48287dc1d3b0d5595113adabd36a847f"
+  integrity sha512-3pdEq3PXALilSJ6dnC4wMWr0AZixHRM4utpdpBR9g5QG7B7JwWyukQv7a9hVxkbGFl+nQbrHDqqQOIBtTXTP/Q==
+  dependencies:
+    find-babel-config "^1.2.0"
+    glob "^7.1.6"
+    pkg-up "^3.1.0"
+    reselect "^4.0.0"
+    resolve "^1.13.1"
+
 babel-plugin-syntax-trailing-function-commas@^7.0.0-beta.0:
   version "7.0.0-beta.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz#aa213c1435e2bffeb6fca842287ef534ad05d5cf"
@@ -3081,6 +3092,14 @@ finalhandler@1.1.2:
     statuses "~1.5.0"
     unpipe "~1.0.0"
 
+find-babel-config@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/find-babel-config/-/find-babel-config-1.2.0.tgz#a9b7b317eb5b9860cda9d54740a8c8337a2283a2"
+  integrity sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==
+  dependencies:
+    json5 "^0.5.1"
+    path-exists "^3.0.0"
+
 find-cache-dir@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
@@ -3275,7 +3294,7 @@ glob-parent@^5.0.0:
   dependencies:
     is-glob "^4.0.1"
 
-glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
+glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -4415,6 +4434,11 @@ json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
+
+json5@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
+  integrity sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=
 
 json5@^2.1.2:
   version "2.1.2"
@@ -5648,6 +5672,13 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
+pkg-up@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-3.1.0.tgz#100ec235cc150e4fd42519412596a28512a0def5"
+  integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
+  dependencies:
+    find-up "^3.0.0"
+
 please-upgrade-node@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"
@@ -6120,6 +6151,11 @@ require-main-filename@^2.0.0:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
+reselect@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
+  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
+
 resolve-cwd@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"
@@ -6156,6 +6192,13 @@ resolve@^1.10.0, resolve@^1.12.0, resolve@^1.15.1, resolve@^1.3.2, resolve@^1.5.
   version "1.15.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.15.1.tgz#27bdcdeffeaf2d6244b95bb0f9f4b4653451f3e8"
   integrity sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==
+  dependencies:
+    path-parse "^1.0.6"
+
+resolve@^1.13.1:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
+  integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
   dependencies:
     path-parse "^1.0.6"
 


### PR DESCRIPTION
This PR includes:

- Install `babel-plugin-module-resolver`
- Add aliases for Components, Constants, Redux, Screens and Services.