### PR TITLE
Add Navigation ref

### DIFF
--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -33,7 +33,7 @@ Button.propTypes = {
   label: string.isRequired,
   customStyles: shape({
     button: ViewPropTypes.style,
-    text: ViewPropTypes.style,
+    text: Text.propTypes.style,
   }),
   onPress: func,
   disabled: bool,

--- a/src/navigation/index.js
+++ b/src/navigation/index.js
@@ -6,6 +6,7 @@ import { useSelector } from 'react-redux';
 import MainStackNavigator from '@navigators/MainStackNavigator';
 import AuthStack from '@navigators/AuthStack';
 
+import { navigationRef } from '@navigators/ref';
 import { MAIN_STACK_NAVIGATOR, AUTH_STACK } from '@constants/screens';
 
 const Stack = createStackNavigator();
@@ -14,9 +15,9 @@ const InitialStack = () => {
   const token = useSelector(({ authReducer: { token } }) => token);
 
   return (
-    <NavigationContainer>
+    <NavigationContainer ref={navigationRef}>
       <Stack.Navigator headerMode="none">
-        {token ? (
+        {!token ? (
           <Stack.Screen name={MAIN_STACK_NAVIGATOR} component={MainStackNavigator} />
         ) : (
           <Stack.Screen name={AUTH_STACK} component={AuthStack} />

--- a/src/navigation/ref.js
+++ b/src/navigation/ref.js
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export const navigationRef = React.createRef();
+
+const navigate = (name, params) => {
+  navigationRef.current?.navigate(name, params);
+};
+
+const replace = (name, params) => {
+  navigationRef.current?.replace(name, params);
+};
+
+export default { navigate, replace };
+

--- a/src/screens/Welcome/index.js
+++ b/src/screens/Welcome/index.js
@@ -9,14 +9,13 @@ import {
 import Button from '../../components/Button';
 import useSetNavigationOptions from '@hooks/useSetNavigationOptions';
 
-import { useNavigation } from '@react-navigation/native';
+import navigation from '@navigators/ref';
 
 import { signOutRequest } from '@actions/authActions';
 
 import styles from './styles';
 
 const Welcome = () => {
-  const navigation = useNavigation();
   useSetNavigationOptions({
     headerTitle: 'Welcome Screen',
     headerLeft: null,


### PR DESCRIPTION
This PR adds a root navigation ref to use everywhere. With this, you can use the navigation object in redux sagas without having to receive it as params or worry it didn't update correctly.